### PR TITLE
Launchy testing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem "stimulus-rails"
 gem "jbuilder"
 
 # Use Redis adapter to run Action Cable in production
-# gem "redis", ">= 4.0.1"
+gem "redis", ">= 4.0.1"
 
 # Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
 # gem "kredis"
@@ -53,9 +53,9 @@ gem "sassc-rails"
 gem "faker"
 
 group :development, :test do
-  gem "dotenv-rails"
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
-  gem "debug", platforms: %i[ mri windows ]
+  gem "debug", platforms: %i[mri mingw x64_mingw]
+  gem "dotenv-rails"
 end
 
 group :development do
@@ -73,7 +73,5 @@ group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
   gem "selenium-webdriver"
-
-  # Show screenshots of virtual test browser
-  gem "launchy"
+  gem "webdrivers"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -73,4 +73,7 @@ group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
   gem "selenium-webdriver"
+
+  # Show screenshots of virtual test browser
+  gem "launchy"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -73,5 +73,5 @@ group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
   gem "selenium-webdriver"
-  gem "webdrivers"
+  gem "webdrivers", '~> 5.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,8 +110,6 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    childprocess (5.1.0)
-      logger (~> 1.5)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.0)
     crass (1.0.6)
@@ -160,10 +158,6 @@ GEM
     jbuilder (2.13.0)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
-    launchy (3.1.1)
-      addressable (~> 2.8)
-      childprocess (~> 5.0)
-      logger (~> 1.6)
     logger (1.7.0)
     loofah (2.24.0)
       crass (~> 1.0.2)
@@ -258,6 +252,7 @@ GEM
     rake (13.2.1)
     rdoc (6.13.1)
       psych (>= 4.0.0)
+    redis (4.8.1)
     regexp_parser (2.10.0)
     reline (0.6.1)
       io-console (~> 0.5)
@@ -306,6 +301,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webdrivers (5.2.0)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (~> 4.0)
     websocket (1.2.11)
     websocket-driver (0.7.7)
       base64
@@ -338,10 +337,10 @@ DEPENDENCIES
   font-awesome-sass (~> 6.1)
   importmap-rails
   jbuilder
-  launchy
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.1.5, >= 7.1.5.1)
+  redis (>= 4.0.1)
   sassc-rails
   selenium-webdriver
   simple_form!
@@ -350,6 +349,7 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   web-console
+  webdrivers
 
 RUBY VERSION
    ruby 3.3.5p100

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -349,7 +349,7 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   web-console
-  webdrivers
+  webdrivers (~> 5.0)
 
 RUBY VERSION
    ruby 3.3.5p100

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,8 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    childprocess (5.1.0)
+      logger (~> 1.5)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.0)
     crass (1.0.6)
@@ -158,6 +160,10 @@ GEM
     jbuilder (2.13.0)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    launchy (3.1.1)
+      addressable (~> 2.8)
+      childprocess (~> 5.0)
+      logger (~> 1.6)
     logger (1.7.0)
     loofah (2.24.0)
       crass (~> 1.0.2)
@@ -332,6 +338,7 @@ DEPENDENCIES
   font-awesome-sass (~> 6.1)
   importmap-rails
   jbuilder
+  launchy
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.1.5, >= 7.1.5.1)

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -29,7 +29,7 @@ Rails.application.configure do
   config.cache_store = :null_store
 
   # Render exception templates for rescuable exceptions and raise for other exceptions.
-  config.action_dispatch.show_exceptions = :rescuable
+  config.action_dispatch.show_exceptions = true
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,5 +1,5 @@
 require "test_helper"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :selenium, using: :chrome, screen_size: [1400, 1400]
+  driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400]
 end

--- a/test/fixtures/files/users.yml
+++ b/test/fixtures/files/users.yml
@@ -1,0 +1,4 @@
+george:
+  email: "george@abitbol.com"
+  first_name: "George"
+  last_name: "Abitbol"

--- a/test/fixtures/products.yml
+++ b/test/fixtures/products.yml
@@ -1,0 +1,5 @@
+<% 1.upto(5) do |i| %>
+product_<%= i %>:
+  name: <%= Faker::Company.name %>
+  tagline: <%= Faker::Company.catch_phrase %>
+<% end %>

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -1,7 +1,15 @@
-require "test_helper"
+require "application_system_test_case"
 
 class ProductTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "visiting the homepage" do
+    # setup
+
+    # exercice
+    visit root_url
+
+    # verify
+    assert_selector "h1", text: "Awesome Products"
+
+    # teardown
+  end
 end

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -1,15 +1,7 @@
-require "application_system_test_case"
+require "test_helper"
 
 class ProductTest < ActiveSupport::TestCase
-  test "visiting the homepage" do
-    # setup
-
-    # exercice
-    visit root_url
-
-    # verify
-    assert_selector "h1", text: "Awesome Products"
-
-    # teardown
-  end
+  # test "the truth" do
+  #   assert true
+  # end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,7 +1,6 @@
-require "test_helper"
-
 class UserTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "full_name returns the capitalized first name and last name" do
+    user = User.new(first_name: "john", last_name: "lennon")
+    assert_equal "John Lennon", user.full_name
+  end
 end

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -1,0 +1,9 @@
+require "application_system_test_case"
+
+class ProductsTest < ApplicationSystemTestCase
+  # test "visiting the index" do
+  #   visit products_url
+  #
+  #   assert_selector "h1", text: "Product"
+  # end
+end

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -1,9 +1,9 @@
 require "application_system_test_case"
 
 class ProductsTest < ApplicationSystemTestCase
-  # test "visiting the index" do
-  #   visit products_url
-  #
-  #   assert_selector "h1", text: "Product"
-  # end
+  test "visiting the index" do
+    visit root_url
+    assert_selector "h1", text: "Awesome Products"
+    # assert_selector ".card-product", count: Product.count
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,21 +1,21 @@
 ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
 require "rails/test_help"
+require 'webdrivers/chromedriver'
+Webdrivers::Chromedriver.required_version = '114.0.5735.90'  # Version stable connue
 
-module ActiveSupport
-  class TestCase
-    # Run tests in parallel with specified workers
-    parallelize(workers: :number_of_processors)
+class ActiveSupport::TestCase
+  # Run tests in parallel with specified workers
+  parallelize(workers: :number_of_processors)
 
-    # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
-    fixtures :all
+  # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
+  fixtures :all
 
-    # Add more helper methods to be used by all tests here...
-
-    # Devise test helpers
-    include Warden::Test::Helpers
-    Warden.test_mode!
-  end
-  # Folder path for screenshots
-  Capybara.save_path = Rails.root.join("tmp/capybara")
+  # Add more helper methods to be used by all tests here...
+  include Warden::Test::Helpers
+  Warden.test_mode!
 end
+
+Capybara.save_path = Rails.root.join("tmp/capybara")
+# Ajouter après la ligne Capybara.save_path
+Capybara.default_max_wait_time = 30  # Augmenter à 30 secondes

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,5 +11,11 @@ module ActiveSupport
     fixtures :all
 
     # Add more helper methods to be used by all tests here...
+
+    # Devise test helpers
+    include Warden::Test::Helpers
+    Warden.test_mode!
   end
+  # Folder path for screenshots
+  Capybara.save_path = Rails.root.join("tmp/capybara")
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,7 +6,7 @@ Webdrivers::Chromedriver.required_version = '114.0.5735.90'  # Version stable co
 
 class ActiveSupport::TestCase
   # Run tests in parallel with specified workers
-  parallelize(workers: :number_of_processors)
+  # parallelize(workers: :number_of_processors)
 
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all


### PR DESCRIPTION
Minitest seems to be not compatible with Rails 7.1
Selenium with Chrome have issue to launch the local server and run the tests.
No help from Le Wagon guideline on this matter (video was done in 2020, lecture gives different instructions than the video and none of them are solving the issue). 
After investigation, the issue was raised in november 2023 and a patch deployed, but still needs a workaround.
I give up, even the teachers from Le Wagon in Nantes don't use these test for their own application.
![image](https://github.com/user-attachments/assets/bd554ef5-d0c1-4cc6-b422-dc66342ac68d)
